### PR TITLE
fixed:官网navbar导航单击quickstart无法高亮

### DIFF
--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -16,6 +16,7 @@
       <li>
         <router-link
           class="nav-link"
+          active-class="is-active"
           :to="{ path: '/' + $route.meta.language + '/quickstart' }">Quickstart</router-link>
       </li>
       <li>


### PR DESCRIPTION
官网navbar导航单击quickstart无法高亮