### PR TITLE
datetimePick add the Description of  the property of 'value'

### DIFF
--- a/src/pages/en2/datetime-picker.md
+++ b/src/pages/en2/datetime-picker.md
@@ -28,7 +28,7 @@ The `type` attribute configures the type of the component, and it has three opti
   <mt-datetime-picker
     ref="picker"
     type="time"
-    v-model="pickerValue">
+    v-model="value">
   </mt-datetime-picker>
 </template>
 
@@ -47,7 +47,7 @@ You can configure a custom template for slot options. The template should be a s
 
 ```html
 <mt-datetime-picker
-  v-model="pickerVisible"
+  v-model="value"
   type="date"
   year-format="{value} 年"
   month-format="{value} 月"
@@ -59,7 +59,7 @@ When the confirm button is tapped, the `confirm` event triggers with `value` as 
 
 ```html
 <mt-datetime-picker
-  v-model="pickerVisible"
+  v-model="value"
   type="time"
   @confirm="handleConfirm">
 </mt-datetime-picker>
@@ -68,6 +68,7 @@ When the confirm button is tapped, the `confirm` event triggers with `value` as 
 ## API
 | option | description | type | acceptable values | default |
 |------|-------|---------|-------|--------|
+| value | value of the picker | Date / String (for example: 2018-1-1 00:00:00 , 2018/1/1 00:00:00 or 2018.1.1 00:00:00))| | |
 | type | type of the picker | String | 'datetime', 'date', 'time' | 'datetime' |
 | cancelText | text of the cancel button | String | | '取消' |
 | confirmText | text of the confirm button | String | | '确定' |
@@ -84,5 +85,5 @@ When the confirm button is tapped, the `confirm` event triggers with `value` as 
 ## Events
 | event name | description | parameters |
 |------|-------|---------|
-| confirm | callback when the confirm button is clicked | current value of the picker |
+| confirm | callback when the confirm button is clicked | current value of the picker (is type of Date)|
 | changeVisible | callback when pop open or close | current value of pop visible |

--- a/src/pages/zh-cn2/datetime-picker.md
+++ b/src/pages/zh-cn2/datetime-picker.md
@@ -28,7 +28,7 @@ Vue.component(DatetimePicker.name, DatetimePicker);
   <mt-datetime-picker
     ref="picker"
     type="time"
-    v-model="pickerValue">
+    v-model="value">
   </mt-datetime-picker>
 </template>
 
@@ -47,7 +47,7 @@ Vue.component(DatetimePicker.name, DatetimePicker);
 
 ```html
 <mt-datetime-picker
-  v-model="pickerVisible"
+  v-model="value"
   type="date"
   year-format="{value} 年"
   month-format="{value} 月"
@@ -59,7 +59,7 @@ Vue.component(DatetimePicker.name, DatetimePicker);
 
 ```html
 <mt-datetime-picker
-  v-model="pickerVisible"
+  v-model="value"
   type="time"
   @confirm="handleConfirm">
 </mt-datetime-picker>
@@ -68,6 +68,7 @@ Vue.component(DatetimePicker.name, DatetimePicker);
 ## API
 | 参数 | 说明 | 类型 | 可选值 | 默认值 |
 |------|-------|---------|-------|--------|
+| value | 绑定值 | Date / String(如：2018-1-1 00:00:00 , 2018/1/1 00:00:00 或者 2018.1.1 00:00:00) | | |
 | type | 组件的类型 | String | 'datetime', 'date', 'time' | 'datetime' |
 | cancelText | 取消按钮文本 | String | | '取消' |
 | confirmText | 确定按钮文本 | String | | '确定' |
@@ -85,5 +86,5 @@ Vue.component(DatetimePicker.name, DatetimePicker);
 ## Events
 | 事件名称 | 说明 | 回调参数 |
 |------|-------|---------|
-| confirm | 点击确认按钮时的回调函数 | 目前的选择值 |
+| confirm | 点击确认按钮时的回调函数 | 目前的选择值(为Date类型) |
 | changeVisible | 改变弹窗显示隐藏的回调函数 | 弹窗是否可见 |


### PR DESCRIPTION
when I use the  Datetime-picker through the vue2 docs,I was confused by the description .
the 'pickerVisible' I think  it as a type of Boolean. so get the error 't.getFullYear is not a function'.
Now,I know the property in vue1 is 的 type of Boolean，but the docs is not change。so , I did some change.
1. change the  variable name bound to v-model

2. add some description about the type of value，add in API