### PR TITLE
引入组件不可使用Vue.use函数

### DIFF
--- a/src/pages/zh-cn2/quickstart.md
+++ b/src/pages/zh-cn2/quickstart.md
@@ -68,10 +68,6 @@ import App from './App.vue'
 
 Vue.component(Button.name, Button)
 Vue.component(Cell.name, Cell)
-/* 或写为
- * Vue.use(Button)
- * Vue.use(Cell)
- */
 
 new Vue({
   el: '#app',


### PR DESCRIPTION
建议去掉`use`, 在`vue 2.5.2`版本中, `ues`需要组件包含`install`的方法, 参考<https://cn.vuejs.org/v2/api/#Vue-use>, 而这里并没有, 会导致组建无法正常使用.