### PR TITLE
FIX: In Quickstart babel-plugin-component babel config err

### DIFF
--- a/src/pages/en/quickstart.md
+++ b/src/pages/en/quickstart.md
@@ -52,12 +52,11 @@ Then edit .babelrc:
   "presets": [
     ["es2015", { "modules": false }]
   ],
-  "plugins": [["component", [
-    {
+  "plugins": [["component", {
       "libraryName": "mint-ui",
       "style": true
     }
-  ]]]
+  ]]
 }
 ```
 

--- a/src/pages/en2/quickstart.md
+++ b/src/pages/en2/quickstart.md
@@ -52,12 +52,11 @@ Then edit .babelrc:
   "presets": [
     ["es2015", { "modules": false }]
   ],
-  "plugins": [["component", [
-    {
+  "plugins": [["component", {
       "libraryName": "mint-ui",
       "style": true
     }
-  ]]]
+  ]]
 }
 ```
 

--- a/src/pages/zh-cn/quickstart.md
+++ b/src/pages/zh-cn/quickstart.md
@@ -50,12 +50,11 @@ npm install babel-plugin-component -D
   "presets": [
     ["es2015", { "modules": false }]
   ],
-  "plugins": [["component", [
-    {
+  "plugins": [["component", {
       "libraryName": "mint-ui",
       "style": true
     }
-  ]]]
+  ]]
 }
 ```
 

--- a/src/pages/zh-cn2/quickstart.md
+++ b/src/pages/zh-cn2/quickstart.md
@@ -50,12 +50,11 @@ npm install babel-plugin-component -D
   "presets": [
     ["es2015", { "modules": false }]
   ],
-  "plugins": [["component", [
-    {
+  "plugins": [["component", {
       "libraryName": "mint-ui",
       "style": true
     }
-  ]]]
+  ]]
 }
 ```
 


### PR DESCRIPTION
`{
  "presets": [
    ["es2015", { "modules": false }]
  ],
  "plugins": [["component", [
    {
      "libraryName": "mint-ui",
      "style": true
    }
  ]]]
}`

The bracket after "component" cause an error